### PR TITLE
handle gcp exceptions

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -90,13 +90,16 @@ def get_time_series(metric_descriptor, value):
   return series
 
 def report():
-  create_time_series([
-    get_time_series(CPU_UTILIZATION_METRIC, { 'double_value': ps.cpu_percent() }),
-    get_time_series(MEMORY_UTILIZATION_METRIC, { 'double_value': memory_used / MEMORY_SIZE * 100 }),
-    get_time_series(DISK_UTILIZATION_METRIC, { 'double_value': disk_used / DISK_SIZE * 100 }),
-    get_time_series(DISK_READS_METRIC, { 'double_value': (disk_io('read_count') - disk_reads) / report_time }),
-    get_time_series(DISK_WRITES_METRIC, { 'double_value': (disk_io('write_count') - disk_writes) / report_time }),
-  ])
+  try:
+    create_time_series([
+      get_time_series(CPU_UTILIZATION_METRIC, { 'double_value': ps.cpu_percent() }),
+      get_time_series(MEMORY_UTILIZATION_METRIC, { 'double_value': memory_used / MEMORY_SIZE * 100 }),
+      get_time_series(DISK_UTILIZATION_METRIC, { 'double_value': disk_used / DISK_SIZE * 100 }),
+      get_time_series(DISK_READS_METRIC, { 'double_value': (disk_io('read_count') - disk_reads) / report_time }),
+      get_time_series(DISK_WRITES_METRIC, { 'double_value': (disk_io('write_count') - disk_writes) / report_time }),
+    ])
+  except Exception as e:
+    print(e)
 
 ### Define constants
 

--- a/monitor.py
+++ b/monitor.py
@@ -90,16 +90,13 @@ def get_time_series(metric_descriptor, value):
   return series
 
 def report():
-  try:
-    create_time_series([
-      get_time_series(CPU_UTILIZATION_METRIC, { 'double_value': ps.cpu_percent() }),
-      get_time_series(MEMORY_UTILIZATION_METRIC, { 'double_value': memory_used / MEMORY_SIZE * 100 }),
-      get_time_series(DISK_UTILIZATION_METRIC, { 'double_value': disk_used / DISK_SIZE * 100 }),
-      get_time_series(DISK_READS_METRIC, { 'double_value': (disk_io('read_count') - disk_reads) / report_time }),
-      get_time_series(DISK_WRITES_METRIC, { 'double_value': (disk_io('write_count') - disk_writes) / report_time }),
-    ])
-  except Exception as e:
-    print(e)
+  create_time_series([
+    get_time_series(CPU_UTILIZATION_METRIC, { 'double_value': ps.cpu_percent() }),
+    get_time_series(MEMORY_UTILIZATION_METRIC, { 'double_value': memory_used / MEMORY_SIZE * 100 }),
+    get_time_series(DISK_UTILIZATION_METRIC, { 'double_value': disk_used / DISK_SIZE * 100 }),
+    get_time_series(DISK_READS_METRIC, { 'double_value': (disk_io('read_count') - disk_reads) / report_time }),
+    get_time_series(DISK_WRITES_METRIC, { 'double_value': (disk_io('write_count') - disk_writes) / report_time }),
+  ])
 
 ### Define constants
 
@@ -209,8 +206,11 @@ signal(SIGTERM, signal_handler)
 
 reset()
 while running:
-  measure()
-  if report_time >= REPORT_TIME_SEC:
-    report()
-    reset()
+  try:
+    measure()
+    if report_time >= REPORT_TIME_SEC:
+        report()
+        reset()
+  except Exception as e:
+    print(e)
 exit(0)


### PR DESCRIPTION
## Problem
If monitor script fails during pipeline execution the pipeline run status becomes failed too even if pipeline execution hasn't any errors. The most common failure reason is the error with GCP provider (e.g `ServiceUnavailable: 503 Socket closed`). 
## Solution 
Catch exceptions during GCP provider works